### PR TITLE
create linked scatterplots of three embeddings

### DIFF
--- a/umap_spec_CLIP_LiT_combined.ipynb
+++ b/umap_spec_CLIP_LiT_combined.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "28e6eb67-33b1-470b-8ae2-255af7c4821b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import umap\n",
+    "import re\n",
+    "import jscatter\n",
+    "# Assuming embeddings are in the second column and are stored as strings\n",
+    "# Example of embedding: \"[0.23, 0.35, 0.11]\"\n",
+    "import ast  # ast.literal_eval safely evaluates a string containing a Python literal expression\n",
+    "\n",
+    "# Initialize UMAP. Reduce dimensionality t 2D for easy visualization.\n",
+    "# Create a UMAP instance with custom parameters\n",
+    "reducer = umap.UMAP(\n",
+    "    n_neighbors=50,\n",
+    "    n_components=2,\n",
+    "    metric='euclidean',\n",
+    "    min_dist=0.5,\n",
+    "    spread=0.5,\n",
+    "    learning_rate=1.0,\n",
+    "    n_epochs=200,\n",
+    "    init='spectral'\n",
+    ")\n",
+    "\n",
+    "def remove_slash(s):\n",
+    "    return s[1:]\n",
+    "\n",
+    "def extract_substring(s):\n",
+    "    # Use a regular expression to find the point at which to stop\n",
+    "    match = re.search(r'_(p|m|sw|s)', s)\n",
+    "    if match:\n",
+    "        return s[:match.start()]\n",
+    "    return s  # Return the whole string if no match is found\n",
+    "\n",
+    "def attach_image(s):    \n",
+    "    return \"https://raw.githubusercontent.com/huyen-nguyen/spec-image-embeddings/main/screenshots/\" + s[:-4] + \"png\"  # Return the whole string if no match is found\n",
+    "\n",
+    "def attach_image_from_non_spec(s):    \n",
+    "    return \"https://raw.githubusercontent.com/huyen-nguyen/spec-image-embeddings/main/screenshots/\" + s  # Return the whole string if no match is found"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55969f94-4df9-483f-8226-c88e36140d0e",
+   "metadata": {},
+   "source": [
+    "## Embeddings from Specs, LiT, and CLIP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "374b54a7-a063-4946-946f-6bf1ba911eaa",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "089f60bb58ed4160a37b9532348ec283",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GridBox(children=(HBox(children=(VBox(children=(Button(button_style='primary', icon='arrows', layout=Layout(wi…"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# --------- Load Spec Data and Apply UMAP ----------\n",
+    "\n",
+    "# Load the CSV file into a DataFrame\n",
+    "df_spec = pd.read_csv('embeddings/spec_embeddings.csv')\n",
+    "\n",
+    "# Assume 'filename' is the column to exclude from embeddings\n",
+    "filename_spec = df_spec['filename']\n",
+    "\n",
+    "# Extract all other columns as embeddings\n",
+    "embeddings_spec = df_spec.drop('filename', axis=1)\n",
+    "\n",
+    "# Apply UMAP \n",
+    "umap_embeddings_spec = reducer.fit_transform(embeddings_spec)\n",
+    "\n",
+    "# --------- Load LiT Data and Apply UMAP ----------\n",
+    "\n",
+    "# Specify column names\n",
+    "column_names = ['Filename', 'Embeddings']\n",
+    "\n",
+    "# Load the CSV file\n",
+    "df_lit = pd.read_csv('embeddings/image_lit_embeddings.tsv', delimiter='\\t', names=column_names)\n",
+    "\n",
+    "df_lit['embeddings'] = df_lit['Embeddings'].apply(ast.literal_eval)\n",
+    "df_lit['filename'] = df_lit['Filename'].apply(remove_slash)\n",
+    "\n",
+    "# Accessing the embedding for the first row\n",
+    "first_embedding = df_lit.loc[0, 'embeddings']\n",
+    "\n",
+    "# Assuming 'df' is your DataFrame and it contains an 'embeddings' column with your embeddings data\n",
+    "# Convert embeddings list into a proper format if necessary\n",
+    "embeddings = list(df_lit['embeddings'])\n",
+    "\n",
+    "umap_embeddings_lit = reducer.fit_transform(embeddings)\n",
+    "\n",
+    "# --------- Load CLIP Data and Apply UMAP ----------\n",
+    "\n",
+    "# Load the CSV file\n",
+    "df_clip = pd.read_csv('embeddings/image_clip_embeddings.csv')\n",
+    "\n",
+    "df_clip['embeddings'] = df_clip['Embeddings'].apply(ast.literal_eval)\n",
+    "# Accessing the embedding for the first row\n",
+    "first_embedding = df_clip.loc[0, 'embeddings']\n",
+    "\n",
+    "# Assuming 'df' is your DataFrame and it contains an 'embeddings' column with your embeddings data\n",
+    "# Convert embeddings list into a proper format if necessary\n",
+    "embeddings = list(df_clip['embeddings'])\n",
+    "\n",
+    "umap_embeddings_clip = reducer.fit_transform(embeddings)\n",
+    "\n",
+    "# --------- Prepare labels ---------\n",
+    "\n",
+    "# Apply the function to the 'Label' column\n",
+    "df_spec['label'] = df_spec['filename'].apply(extract_substring)\n",
+    "df_lit['label'] = df_lit['filename'].apply(extract_substring)\n",
+    "df_clip['label'] = df_clip['Filename'].apply(extract_substring)\n",
+    "\n",
+    "# Display the DataFrame to see the original and trimmed labels\n",
+    "# print(df)\n",
+    "\n",
+    "# ----------- Apply labels -------------\n",
+    "\n",
+    "# Convert the embeddings to a DataFrame\n",
+    "umap_embeddings_spec = pd.DataFrame(umap_embeddings_spec, columns=['UMAP_1', 'UMAP_2'])\n",
+    "umap_embeddings_lit = pd.DataFrame(umap_embeddings_lit, columns=['UMAP_1', 'UMAP_2'])\n",
+    "umap_embeddings_clip = pd.DataFrame(umap_embeddings_clip, columns=['UMAP_1', 'UMAP_2'])\n",
+    "\n",
+    "# Add the labels to the DataFrame\n",
+    "umap_embeddings_spec['Label'] = df_spec['label']\n",
+    "umap_embeddings_lit['Label'] = df_lit['label']\n",
+    "umap_embeddings_clip['Label'] = df_clip['label']\n",
+    "\n",
+    "umap_embeddings_spec[\"url\"] = df_spec['filename'].apply(attach_image)\n",
+    "umap_embeddings_lit[\"url\"] = df_lit['filename'].apply(attach_image_from_2)\n",
+    "umap_embeddings_clip[\"url\"] = df_clip['Filename'].apply(attach_image_from_2)\n",
+    "\n",
+    "# ----------- Combine -------------\n",
+    "\n",
+    "combined = umap_embeddings_clip.merge(umap_embeddings_lit, on=['Label', 'url'], how='left').merge(umap_embeddings_clip, on=['Label', 'url'], how='left')\n",
+    "combined = combined.rename(columns={\"UMAP_1_x\": \"UMAP_1_spec\", \"UMAP_2_x\": \"UMAP_2_spec\", \"UMAP_1_y\": \"UMAP_1_lit\", \"UMAP_2_y\": \"UMAP_2_lit\", \"UMAP_1\": \"UMAP_1_clip\", \"UMAP_2\": \"UMAP_2_clip\"})\n",
+    "combined\n",
+    "\n",
+    "# Display the first few rows of the DataFrame\n",
+    "# print(umap_embeddings_spec.head())\n",
+    "\n",
+    "# ----------- Config -------------\n",
+    "\n",
+    "# API Reference: https://github.com/flekschas/jupyter-scatter\n",
+    "# and also https://github.com/flekschas/regl-scatterplot/#properties\n",
+    "config = {\n",
+    "    \"color_by\": 'Label',\n",
+    "    \"size\": 7,\n",
+    "    \"axes_labels\": True,\n",
+    "    \"height\": 800,\n",
+    "    \"background\": \"dark\",\n",
+    "    \"legend\": True,\n",
+    "    # \"aspectRatio\": 1,\n",
+    "    \"opacity\": 0.8,\n",
+    "    \"axes_grid\": True,\n",
+    "    \"tooltip\": True,\n",
+    "    \"tooltip_preview\": \"url\",\n",
+    "    \"tooltip_preview_type\": \"image\",\n",
+    "    \"tooltip_preview_image_background_color\": \"white\",\n",
+    "    \"tooltip_properties\": [\"color\"],\n",
+    "    \"data\": combined\n",
+    "}\n",
+    "\n",
+    "# ----------- Plotting the results using jupyter scatter -----------\n",
+    "jscatter.compose(\n",
+    "    [\n",
+    "        jscatter.Scatter(\n",
+    "            x=\"UMAP_1_spec\", y=\"UMAP_2_spec\", **config,\n",
+    "        ),\n",
+    "        jscatter.Scatter(\n",
+    "            x=\"UMAP_1_lit\", y=\"UMAP_2_lit\", **config,\n",
+    "        ),\n",
+    "        jscatter.Scatter(\n",
+    "            x=\"UMAP_1_clip\", y=\"UMAP_2_clip\", **config\n",
+    "        )\n",
+    "    ],\n",
+    "    sync_selection=True,\n",
+    "    sync_hover=True,\n",
+    "    rows=1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "7ac29bee-aac6-4236-9568-adf03935ac9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/var/folders/gt/f9y6f2l93wj459z7zbwd4gc80000gq/T/ipykernel_28806/3568417402.py:2: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`\n",
+      "  umap_embeddings_lit[umap_embeddings_lit.Label == 'heatmap'].url[0]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'https://raw.githubusercontent.com/huyen-nguyen/spec-image-embeddings/main/screenshots/heatmap_sw_1_2_s_1_0png'"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(umap_embeddings_lit)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Created a notebook `umap_spec_CLIP_LiT_combined.ipynb` that creates three scatterplots (spec, lit, clip) that are linked, i.e., selecting points in a scatterplot highlights the corresponding points in the rest.

![Screenshot 2024-04-26 at 12 20 49 PM](https://github.com/huyen-nguyen/spec-image-embeddings/assets/9922882/85113701-adb1-43df-9cd5-27faacffc164)
